### PR TITLE
Added FFI example using multiple C objects and headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ Basically remember these:
 :module ModuleName
 ```
 
+## FFI
+
+This project also demonstrates how to use the FFI. C source files are located in `csrc`, while the C headers are in `include`.
+
+The relevant attributes of `package.yaml` are `c-sources`, `include-dirs` and `install-includes`.
+
+The `c-sources` be a list of C files that need to be compiled into objects that are linked during compilation.
+
+The `include-dirs` is a list of directories containing C headers to be included. In this case, we have only pointed to `include` because we are only using standard library headers and our own headers. But you can also point to system directories using absolute paths.
+
+The `install-includes` will ensure that these headers (relative to the include-dirs) are also exported to any downstream package that depends on this package. So they can make use of those same headers, if they were also writing their own C code.
+
+Finally you just need to write code like `FFI.hs`, and everything just works normally.
+
 ---
 
 Because Haskell is a compiled language, most building tools are `nativeBuildInputs`. However for the `shell.nix` this distinction doesn't matter, because it just puts you into an environment that has all the dependencies.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,16 @@
 module Main where
 
-import Lib
+import qualified FFI as F
+import           Lib (someFunc)
 
 main :: IO ()
-main = someFunc
+main = do
+  time <- F.getTime
+  let pi = F.getPi
+  let negPi = F.getNegPi
+  let sum = F.negAdd 1 2
+  putStrLn $ show time
+  putStrLn $ show pi
+  putStrLn $ show negPi
+  putStrLn $ show sum
+  someFunc

--- a/csrc/algebra.c
+++ b/csrc/algebra.c
@@ -1,0 +1,9 @@
+#include "mathematics.h"
+
+int neg_add(int x, int y) {
+  return add(-x, -y);
+}
+
+double get_neg_pi() {
+  return -get_pi();
+}

--- a/csrc/mathematics.c
+++ b/csrc/mathematics.c
@@ -1,0 +1,7 @@
+int add(int x, int y) {
+  return x + y;
+}
+
+double get_pi() {
+  return 3.1415926;
+}

--- a/include/algebra.h
+++ b/include/algebra.h
@@ -1,0 +1,3 @@
+int neg_add(int x, int y);
+
+double get_neg_pi();

--- a/include/mathematics.h
+++ b/include/mathematics.h
@@ -1,0 +1,3 @@
+int add(int x, int y);
+
+double get_pi();

--- a/package.yaml
+++ b/package.yaml
@@ -17,8 +17,17 @@ dependencies:
 
 library:
   source-dirs: src
+  c-sources:
+    - csrc/mathematics.c
+    - csrc/algebra.c
+  include-dirs:
+    - include
+  install-includes:
+    - mathematics.h
+    - algebra.h
   exposed-modules:
     - Lib
+    - FFI
 
 executables:
   haskell-demo-exe:

--- a/src/FFI.hs
+++ b/src/FFI.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module FFI
+    ( getTime
+    , add
+    , getPi
+    , getNegPi
+    , negAdd
+    ) where
+
+import           Foreign.C
+import           Foreign.Ptr (Ptr, nullPtr)
+import           Prelude     hiding (sin)
+
+-- |A pure stdlib foreign function
+foreign import ccall "sin" c_sin :: CDouble -> CDouble
+sin :: Double -> Double
+sin d = realToFrac (c_sin (realToFrac d))
+
+-- |An impure stdlib function
+foreign import ccall "time" c_time :: Ptr a -> IO CTime
+getTime :: IO Int
+getTime = c_time nullPtr >>= (return . fromEnum)
+
+-- |A pure custom function
+foreign import ccall "add" c_add :: CInt -> CInt -> CInt
+add :: Int -> Int -> Int
+add x y = fromIntegral $ c_add (fromIntegral x) (fromIntegral y)
+
+-- |Another pure custom function
+foreign import ccall "get_pi" c_get_pi :: CDouble
+getPi :: Double
+getPi = realToFrac c_get_pi
+
+-- |Another pure custom function demonstrating the usage of multiple C sources
+foreign import ccall "get_neg_pi" c_get_neg_pi :: CDouble
+getNegPi :: Double
+getNegPi = realToFrac c_get_neg_pi
+
+-- |Another pure custom function demonstrating the usage of multiple C sources
+foreign import ccall "neg_add" c_neg_add :: CInt -> CInt -> CInt
+negAdd :: Int -> Int -> Int
+negAdd x y = fromIntegral $ c_neg_add (toEnum x) (toEnum y)
+


### PR DESCRIPTION
This adds an example of using FFI into the Haskell-Demo. Especially in terms of the combination between Nix, Cabal, Hpack... etc.

No example of `c2hs` or `Storable` nor usage of a system library. I'm thinking we should demonstrate something like using `zlib` as a `nativeBuildInput` in `default.nix` and then using it in the example, and seeing how that header is included, and whether we need to put in some environment variables or something.

Relevant issue: https://github.com/sol/hpack/issues/355