### PR TITLE
Add runtime dependency example

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -1,2 +1,55 @@
-import Distribution.Simple
-main = defaultMain
+import           Data.Char
+import           Data.Maybe
+import           Distribution.PackageDescription
+import           Distribution.Simple
+import           Distribution.Simple.LocalBuildInfo
+import           Distribution.Simple.Program
+import           Distribution.Simple.Setup
+
+main :: IO ()
+main = defaultMainWithHooks simpleUserHooks
+  { hookedPrograms = map simpleProgram programs
+  , confHook       = configure
+  }
+
+programs :: [String]
+programs = ["hello"]
+
+configure
+  :: (GenericPackageDescription, HookedBuildInfo)
+  -> ConfigFlags
+  -> IO LocalBuildInfo
+configure (gpd, hbi) flags = do
+  lbi' <- confHook simpleUserHooks (gpd, hbi) flags
+  let paths = map
+        (\p ->
+          ( p
+          , maybe p
+                  programPath
+                  (lookupProgram (simpleProgram p) (withPrograms lbi))
+          )
+        )
+        programs
+      descr = localPkgDescr lbi'
+      lib   = fromJust (library descr)
+      libbi = libBuildInfo lib
+      lbi   = lbi'
+        { localPkgDescr = descr
+          { library = Just
+            (lib
+              { libBuildInfo = libbi
+                                 { cppOptions = cppOptions libbi
+                                                  ++ map fmtCppArg paths
+                                 }
+              }
+            )
+          }
+        }
+  return lbi
+
+fmtCppArg :: (String, FilePath) -> String
+fmtCppArg (prg, path) = "-DPATH_TO_" ++ map mangle prg ++ "=" ++ show path
+ where
+  mangle :: Char -> Char
+  mangle '-' = '_'
+  mangle c   = toUpper c

--- a/app/deps/Main.hs
+++ b/app/deps/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import           Deps                           ( sayHello )
+
+main :: IO ()
+main = sayHello

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
-{ mkDerivation, base, data-default-class, hpack, http-types
+{ mkDerivation, base, data-default-class, hello, hpack, http-types
 , iproute, monad-logger, mtl, network, safe-exceptions, stdenv
-, text, transformers, wai, warp
+, text, transformers, typed-process, wai, warp
 }:
 mkDerivation {
   pname = "haskell-demo";
@@ -10,17 +10,19 @@ mkDerivation {
   isExecutable = true;
   libraryHaskellDepends = [
     base data-default-class http-types iproute monad-logger mtl network
-    safe-exceptions text transformers wai warp
+    safe-exceptions text transformers typed-process wai warp
   ];
-  libraryToolDepends = [ hpack ];
+  libraryToolDepends = [ hello hpack ];
   executableHaskellDepends = [
     base data-default-class http-types iproute monad-logger mtl network
-    safe-exceptions text transformers wai warp
+    safe-exceptions text transformers typed-process wai warp
   ];
+  executableToolDepends = [ hello ];
   testHaskellDepends = [
     base data-default-class http-types iproute monad-logger mtl network
-    safe-exceptions text transformers wai warp
+    safe-exceptions text transformers typed-process wai warp
   ];
+  testToolDepends = [ hello ];
   prePatch = "hpack";
   homepage = "https://github.com/MatrixAI/Haskell-Demo#readme";
   license = stdenv.lib.licenses.asl20;

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,10 @@ dependencies:
 - http-types
 - data-default-class
 - text
+- typed-process
+
+system-build-tools:
+- hello
 
 library:
   source-dirs: src
@@ -41,6 +45,7 @@ library:
     - FFI
     - Demo
     - Library
+    - Deps
 
 executables:
   haskell-demo-ffi-exe:
@@ -64,6 +69,15 @@ executables:
   haskell-demo-library-exe:
     main:                Main.hs
     source-dirs:         app/library
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - haskell-demo
+  haskell-demo-deps-exe:
+    main:                Main.hs
+    source-dirs:         app/deps
     ghc-options:
     - -threaded
     - -rtsopts

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -1,0 +1,11 @@
+-- Demo showing how to bake runtime dependency (e.g. shellout cli programs) 
+-- into the binary so that it becomes part of the closure of the build output
+module Deps where
+
+import           System.Process.Typed           ( runProcess_
+                                                , proc
+                                                )
+import           Deps.Paths                     ( hello )
+
+sayHello :: IO ()
+sayHello = runProcess_ $ proc hello []

--- a/src/Deps/Paths.hs
+++ b/src/Deps/Paths.hs
@@ -1,0 +1,9 @@
+{-# Language CPP #-}
+
+module Deps.Paths
+  ( hello
+  )
+where
+
+hello :: FilePath
+hello = PATH_TO_HELLO


### PR DESCRIPTION
This PR adds an example to bake runtime dependency (e.g. shellout cli programs) 
into the binary so that it becomes part of the closure of the build output.

Based on https://github.com/NixOS/cabal2nix/issues/466

Tries to solve #7 