### PR TITLE
Add mkWrapper example

### DIFF
--- a/app/deps/Main.hs
+++ b/app/deps/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import           Deps                           ( sayHello )
+
+main :: IO ()
+main = sayHello

--- a/cabal.nix
+++ b/cabal.nix
@@ -1,0 +1,29 @@
+{ mkDerivation, base, data-default-class, hello, hpack, http-types
+, iproute, monad-logger, mtl, network, safe-exceptions, stdenv
+, text, transformers, typed-process, wai, warp
+}:
+mkDerivation {
+  pname = "haskell-demo";
+  version = "0.1.0.0";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    base data-default-class http-types iproute monad-logger mtl network
+    safe-exceptions text transformers typed-process wai warp
+  ];
+  libraryToolDepends = [ hello hpack ];
+  executableHaskellDepends = [
+    base data-default-class http-types iproute monad-logger mtl network
+    safe-exceptions text transformers typed-process wai warp
+  ];
+  executableToolDepends = [ hello ];
+  testHaskellDepends = [
+    base data-default-class http-types iproute monad-logger mtl network
+    safe-exceptions text transformers typed-process wai warp
+  ];
+  testToolDepends = [ hello ];
+  prePatch = "hpack";
+  homepage = "https://github.com/MatrixAI/Haskell-Demo#readme";
+  license = stdenv.lib.licenses.asl20;
+}

--- a/default.nix
+++ b/default.nix
@@ -1,27 +1,16 @@
-{ mkDerivation, base, data-default-class, hpack, http-types
-, iproute, monad-logger, mtl, network, safe-exceptions, stdenv
-, text, transformers, wai, warp
-}:
-mkDerivation {
-  pname = "haskell-demo";
-  version = "0.1.0.0";
-  src = ./.;
-  isLibrary = true;
-  isExecutable = true;
-  libraryHaskellDepends = [
-    base data-default-class http-types iproute monad-logger mtl network
-    safe-exceptions text transformers wai warp
-  ];
-  libraryToolDepends = [ hpack ];
-  executableHaskellDepends = [
-    base data-default-class http-types iproute monad-logger mtl network
-    safe-exceptions text transformers wai warp
-  ];
-  testHaskellDepends = [
-    base data-default-class http-types iproute monad-logger mtl network
-    safe-exceptions text transformers wai warp
-  ];
-  prePatch = "hpack";
-  homepage = "https://github.com/MatrixAI/Haskell-Demo#readme";
-  license = stdenv.lib.licenses.asl20;
-}
+{ pkgs ? import ./pkgs.nix }:
+
+with pkgs;
+let
+  drv = (haskellPackages.callPackage ./cabal.nix { inherit hello; });
+in
+  drv.overrideAttrs (attrs: {
+    src = nix-gitignore.gitignoreSource [] ./.;
+    nativeBuildInputs = attrs.nativeBuildInputs ++ [ makeWrapper ];
+    postFixup = ''
+      wrapProgram $out/bin/haskell-demo-deps-exe \
+        --set PATH ${lib.makeBinPath [
+          hello
+        ]}
+    '';
+  })

--- a/package.yaml
+++ b/package.yaml
@@ -25,6 +25,10 @@ dependencies:
 - http-types
 - data-default-class
 - text
+- typed-process
+
+system-build-tools:
+- hello
 
 library:
   source-dirs: src
@@ -41,6 +45,7 @@ library:
     - FFI
     - Demo
     - Library
+    - Deps
 
 executables:
   haskell-demo-ffi-exe:
@@ -64,6 +69,15 @@ executables:
   haskell-demo-library-exe:
     main:                Main.hs
     source-dirs:         app/library
+    ghc-options:
+    - -threaded
+    - -rtsopts
+    - -with-rtsopts=-N
+    dependencies:
+    - haskell-demo
+  haskell-demo-deps-exe:
+    main:                Main.hs
+    source-dirs:         app/deps
     ghc-options:
     - -threaded
     - -rtsopts

--- a/release.nix
+++ b/release.nix
@@ -4,9 +4,7 @@ with pkgs;
 let
   haskellPackages = haskell.packages.ghc865;
   strict = drv: haskell.lib.buildStrictly drv;
-  drv = (haskellPackages.callPackage ./default.nix {}).overrideAttrs (attrs: {
-    src = nix-gitignore.gitignoreSource [] ./.;
-  });
+  drv = haskellPackages.callPackage ./default.nix {};
 in
   rec {
     library = drv;

--- a/shell.nix
+++ b/shell.nix
@@ -16,7 +16,7 @@ in
       echo 'Entering ${attrs.name}'
       set -v
 
-      cabal2nix --hpack . >./default.nix
+      cabal2nix --hpack . >./cabal.nix
       hpack --force
       cabal v2-configure
 

--- a/src/Deps.hs
+++ b/src/Deps.hs
@@ -1,0 +1,7 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Deps where
+
+import           System.Process.Typed           ( runProcess_ )
+
+sayHello :: IO ()
+sayHello = runProcess_ "hello"


### PR DESCRIPTION
Alternative to https://github.com/MatrixAI/Haskell-Demo/pull/23

Instead of baking nix store path into the binary, use the `wrapProgram` utility in postFix stage to put the nix store path onto application's PATH. 

This requires moving back to using `cabal.nix` as the auto generated expression from `cabal2nix` and override the drv in `default.nix` to add the postFix.
